### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ To build the documentation:
 $ mkdocs build
 ```
 
+## Reference Documentation
+https://docs.contour.so/aperohealth/drf-api-tracking/README
+
 
 [build-status-image]: https://secure.travis-ci.org/lingster/drf-api-tracking.png?branch=master
 [travis]: http://travis-ci.org/lingster/drf-api-tracking?branch=master


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!